### PR TITLE
Adjustable datetime column format

### DIFF
--- a/load_balanced/README.md
+++ b/load_balanced/README.md
@@ -52,8 +52,7 @@ resending a message. These and other configurations are described in the
 
 ## Setting Up to Run the Connector
 ### Tying the Connector to Spark
-You may build the code in the IDE of your choice or you may utilize the jar
-located in the repository at 'target/scala-2.12/nats-spark-connector_2.12-0.1.jar'
+You may build the code using `sbt assembly` which will create the jar file.
 After placing the jar in a directory of your choice, point Spark to said
 directory by setting the Spark Session builder option "spark.jars".
 
@@ -188,6 +187,11 @@ Possible options are:
   Specifies the compression type to be used to decompress the payload of the message. 
   Currently supported values are: `"zlib"`,`"uncompressed"` and `"none"`.
   If the payload of a particular message can not be decompressed, it is then passed on as-is.
+
+- "nats.datetime.format"
+  Specifies the format of the date time in the second column of the row, which is the time at
+  which the message was received from NATS (the time the message was recorded into the stream
+  is included in the JS Metadata column JSON).
 
 ### Spark Streaming Sink Options
 An example Scala sink configuration for the NATS connector follows:

--- a/load_balanced/src/main/scala/natsconnector/NatsConfig.scala
+++ b/load_balanced/src/main/scala/natsconnector/NatsConfig.scala
@@ -88,7 +88,7 @@ class NatsConfig(isSource: Boolean) {
   var tlsAlgorithm: Option[String] = None // configurable
 
   // ============== Application Config Values
-  val dateTimeFormat = "MM/dd/yyyy - HH:mm:ss Z"
+  var dateTimeFormat = "MM/dd/yyyy - HH:mm:ss Z" // configurable
 
   // Nats connection
   var options: Option[Options] = None
@@ -132,6 +132,12 @@ class NatsConfig(isSource: Boolean) {
     }
 
     // Optional parameters
+    try {
+      this.dateTimeFormat = parameters("nats.datetime.format")
+    } catch {
+      case e: NoSuchElementException =>
+    }
+
     try {
       this.numListeners = parameters("nats.num.listeners").toInt
     } catch {
@@ -526,7 +532,7 @@ class NatsConfig(isSource: Boolean) {
     if (this.sslContextFactoryClass.isDefined) {
       Class.forName(this.sslContextFactoryClass.get) match {
         case c if classOf[SSLContextFactory].isAssignableFrom(c) =>
-          builder.sslContextFactory(c.asInstanceOf[Class[SSLContextFactory]].newInstance())
+          builder.sslContextFactory(c.asInstanceOf[Class[SSLContextFactory]].getDeclaredConstructor().newInstance())
         case _ =>
           throw new IllegalArgumentException(
             "The class provided for sslContextFactoryClass must be a subclass of SSLContextFactory"

--- a/load_balanced/src/main/scala/natsconnector/NatsSubBatchMgr.scala
+++ b/load_balanced/src/main/scala/natsconnector/NatsSubBatchMgr.scala
@@ -135,13 +135,13 @@ class NatsSubBatchMgr {
     def uncompressed(msg:Message):NatsMsg = {
 
       NatsMsg(msg.getSubject(),
-        msg.metaData().timestamp().format(df),
+        ZonedDateTime.now().format(df),
         msg.getData(), getHeaders(msg), msg.metaData())
     }
 
     def compressed(msg:Message):NatsMsg = {
       NatsMsg(msg.getSubject(),
-        msg.metaData().timestamp().format(df),
+        ZonedDateTime.now().format(df),
         decompress(msg.getData()), getHeaders(msg), msg.metaData())
     }
 


### PR DESCRIPTION
You can now adjust the date time format for the second column which is now the time at which the message was received from NATS (as the time the message was initially received by NATS is in the JS Metadata column data)