### PR TITLE
Fix sink

### DIFF
--- a/load_balanced/src/main/scala/natsconnector/spark/NatsStreamigSink.scala
+++ b/load_balanced/src/main/scala/natsconnector/spark/NatsStreamigSink.scala
@@ -1,6 +1,6 @@
 package natsconnector.spark
 
-import natsconnector.NatsMsg
+import natsconnector.{CoreNatsMsg, NatsMsg}
 //import natsconnector.NatsBatchPublisher
 import natsconnector.NatsConfigSink
 import natsconnector.NatsConfig
@@ -50,9 +50,9 @@ class NatsStreamingSink(sqlContext: SQLContext,
     val df = data.sparkSession.createDataFrame(rdd, data.schema)
 
     val natsMsgDataset = df.map(row =>
-                     new NatsMsg(row.getString(0), row.getString(1), row.getString(2).getBytes, None, null))
+                     new CoreNatsMsg(row.getString(0), row.getString(1), row.getString(2).getBytes(), None))
 
-    val natsMsgs: Seq[NatsMsg] = natsMsgDataset.collect().toSeq
+    val natsMsgs: Seq[CoreNatsMsg] = natsMsgDataset.collect().toSeq
 
     natsMsgs.foreach(msg => sendNatsMsg(msg.subject, msg.dateTime, msg.content))
 


### PR DESCRIPTION
The JS metadata in NatsMsg can not be encoded by Spark which causes the sink to be broken when it was added to the NatsMsg case class. It is anyways not part of message being published to NATS so not relevant to a message being published to a sink. So create a new CoreNatsMsg case class without it and use that instead in the sink code.