### PR TITLE
Adds compressed payload support though an optional config 'nats.pull.subscription.payload.compression', supports zlib or none

### DIFF
--- a/V2/nats-spark-connector/README.md
+++ b/V2/nats-spark-connector/README.md
@@ -35,7 +35,7 @@ val initDF = spark
   .option("nats.credential.file", "/Users/mrosti/shh/...")
   .option("nats.pull.subscription.stream.name", "my-stream")
   .option("nats.pull.subscription.durable.name", "my-stream")
-  .option("nats.pull.subscription.payload.compression", "zlib") // default is "none"
+  .option("nats.storage.payload-compression", "zlib") // default is "none"
   .option("nats.pull.consumer.ack.wait", "90")
   .option("nats.pull.consumer.max.batch", "10")
   .option("nats.stream.subjects", "my.stream.data")

--- a/V2/nats-spark-connector/README.md
+++ b/V2/nats-spark-connector/README.md
@@ -35,6 +35,7 @@ val initDF = spark
   .option("nats.credential.file", "/Users/mrosti/shh/...")
   .option("nats.pull.subscription.stream.name", "my-stream")
   .option("nats.pull.subscription.durable.name", "my-stream")
+  .option("nats.pull.subscription.payload.compression", "zlib") // default is "none"
   .option("nats.pull.consumer.ack.wait", "90")
   .option("nats.pull.consumer.max.batch", "10")
   .option("nats.stream.subjects", "my.stream.data")

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsRDD.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsRDD.scala
@@ -58,7 +58,7 @@ class NatsRDD(sc: SparkContext, natsSourceParams: NatsSourceParams)
         .fetch(natsSourceParams.batchSize, natsSourceParams.maxWait.toMillis)
         .iterator()
         .asScala
-        .map(message => (message.getReplyTo, MessageToSparkRow(message)))
+        .map(message => (message.getReplyTo, MessageToSparkRow(message, natsSourceParams.payloadCompression)))
     })
   }
 

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsSourceConfig.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsSourceConfig.scala
@@ -16,7 +16,9 @@ final case class ConsumerConfig(
 final case class SubscriptionConfig(
     streamName: String,
     createConsumer: Boolean,
-    consumerConfig: ConsumerConfig)
+    consumerConfig: ConsumerConfig,
+    payloadCompression: String // TODO ask about move to ConsumerConfig????
+)
 
 final case class NatsSourceConfig(
     jetStreamConfig: JetStreamConfig,
@@ -44,6 +46,11 @@ object NatsSourceConfig extends Logging {
     // Stream Config
     val streamName = requiredKey(SourcePullSubscriptionNameOption)
     val durableName = requiredKey(SourcePullSubscriptionDurableOption)
+    val payloadCompression = defaultKey(SourcePullSubscriptionCompressionOption, "none")
+    payloadCompression match {
+      case "none" | "zlib" => () 
+      case _ => println(s"Option passed to '$SourcePullSubscriptionCompressionOption' not recognized. Defaulting to 'none'")
+    }
 
     // Consumer Config
     val createConsumer =
@@ -63,7 +70,8 @@ object NatsSourceConfig extends Logging {
       SubscriptionConfig(
         streamName,
         createConsumer,
-        ConsumerConfig(msgAckTime, maxBatch, maxAckPending, filterSubjects, durableName)
+        ConsumerConfig(msgAckTime, maxBatch, maxAckPending, filterSubjects, durableName),
+        payloadCompression
       ),
       batchSize,
       maxWait

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsSourceConfig.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsSourceConfig.scala
@@ -17,7 +17,7 @@ final case class SubscriptionConfig(
     streamName: String,
     createConsumer: Boolean,
     consumerConfig: ConsumerConfig,
-    payloadCompression: String // TODO ask about move to ConsumerConfig????
+    payloadCompression: String
 )
 
 final case class NatsSourceConfig(

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsStreamProvider.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsStreamProvider.scala
@@ -62,7 +62,9 @@ class NatsStreamProvider
         config.subscriptionConfig.streamName,
         config.subscriptionConfig.consumerConfig.durableName,
         config.batchSize,
-        config.maxWait)
+        config.maxWait,
+        config.subscriptionConfig.payloadCompression
+      )
     )
   }
 

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/package.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/package.scala
@@ -10,6 +10,7 @@ package object nats {
   // Subscription Config
   val SourcePullSubscriptionNameOption = "nats.pull.subscription.stream.name"
   val SourcePullSubscriptionDurableOption = "nats.pull.subscription.durable.name"
+  val SourcePullSubscriptionCompressionOption = "nats.pull.subscription.payload.compression"
 
   // Consumer Config
   val SourceConsumerCreateOption = "nats.pull.consumer.create"

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/package.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/package.scala
@@ -10,7 +10,7 @@ package object nats {
   // Subscription Config
   val SourcePullSubscriptionNameOption = "nats.pull.subscription.stream.name"
   val SourcePullSubscriptionDurableOption = "nats.pull.subscription.durable.name"
-  val SourcePullSubscriptionCompressionOption = "nats.pull.subscription.payload.compression"
+  val SourcePullSubscriptionCompressionOption = "nats.storage.payload-compression"
 
   // Consumer Config
   val SourceConsumerCreateOption = "nats.pull.consumer.create"

--- a/V2/nats-spark-connector/src/test/scala/SparkTest.scala
+++ b/V2/nats-spark-connector/src/test/scala/SparkTest.scala
@@ -26,6 +26,7 @@ object SparkTest extends App {
     .option("nats.pull.consumer.create", "false")
     .option("nats.pull.batch.size", "changeme")
     .option("nats.pull.wait.time", "changeme")
+    .option("nats.pull.subscription.payload.compression", "zlib")
     .load()
     .withWatermark("timestamp", "1 minute")
     .writeStream

--- a/V2/nats-spark-connector/src/test/scala/SparkTest.scala
+++ b/V2/nats-spark-connector/src/test/scala/SparkTest.scala
@@ -26,7 +26,7 @@ object SparkTest extends App {
     .option("nats.pull.consumer.create", "false")
     .option("nats.pull.batch.size", "changeme")
     .option("nats.pull.wait.time", "changeme")
-    .option("nats.pull.subscription.payload.compression", "zlib")
+    .option("nats.storage.payload-compression", "zlib")
     .load()
     .withWatermark("timestamp", "1 minute")
     .writeStream

--- a/V2/nats-spark-connector/src/test/scala/org/apache/spark/sql/nats/NatMessageToSparkRowTest.scala
+++ b/V2/nats-spark-connector/src/test/scala/org/apache/spark/sql/nats/NatMessageToSparkRowTest.scala
@@ -1,0 +1,48 @@
+package org.apache.spark.sql.nats
+
+import munit.{FunSuite }
+import java.util.zip.Deflater
+
+class NatMessageToSparkRowTest extends FunSuite  {
+
+  // useful for compressing strings for test
+  // à la GPT
+  def compress(data: String): Array[Byte] = {
+    val bytes = data.getBytes("UTF-8") // Convert string to bytes
+    val deflater = new Deflater()
+    deflater.setInput(bytes)
+    deflater.finish()
+
+    val compressedData = new Array[Byte](bytes.length * 10) // Compressed data can potentially be larger
+    val compressedDataSize = deflater.deflate(compressedData)
+
+    compressedData.take(compressedDataSize) // Return only the used portion of the buffer
+  }
+
+  test("it correctly decompresses simple string") {
+    val originalString = "Hello there"
+    val compressedBytes = compress(originalString)
+    val decompressBytes = MessageToSparkRow.decompress(compressedBytes)
+    val decompressedString = new String(decompressBytes, "UTF-8")
+
+    assertEquals( 
+      originalString,
+      decompressedString
+    )
+  }
+
+  test("it correctly decompresses highly compressable string") {
+    val originalString = "Wheels on the bus go" + (" round and round" * 100000)
+    val compressedBytes = compress(originalString)
+    val decompressBytes = MessageToSparkRow.decompress(compressedBytes)
+    val decompressedString = new String(decompressBytes, "UTF-8")
+
+    // prints: 1600020,3156
+    // println(decompressBytes.length, compressedBytes.length)
+
+    assertEquals( 
+      originalString,
+      decompressedString
+    )
+  }
+}

--- a/V2/nats-spark-connector/src/test/scala/org/apache/spark/sql/nats/NatSourceConfigTest.scala
+++ b/V2/nats-spark-connector/src/test/scala/org/apache/spark/sql/nats/NatSourceConfigTest.scala
@@ -18,7 +18,8 @@ class NatSourceConfigTest extends FunSuite {
       "nats.pull.consumer.max.batch" -> "2",
       "nats.stream.subjects" -> "a,b",
       "nats.pull.batch.size" -> "5",
-      "nats.pull.wait.time" -> "6"
+      "nats.pull.wait.time" -> "6",
+      "nats.pull.subscription.payload.compression" -> "zlib"
     )
     val createConsumer = false
     val expectedConfig = NatsSourceConfig(
@@ -32,7 +33,8 @@ class NatSourceConfigTest extends FunSuite {
           7,
           Seq("a", "b"),
           "durable"
-        )),
+        ),
+        "zlib"),
       5,
       6.seconds
     )

--- a/V2/nats-spark-connector/src/test/scala/org/apache/spark/sql/nats/NatSourceConfigTest.scala
+++ b/V2/nats-spark-connector/src/test/scala/org/apache/spark/sql/nats/NatSourceConfigTest.scala
@@ -19,7 +19,7 @@ class NatSourceConfigTest extends FunSuite {
       "nats.stream.subjects" -> "a,b",
       "nats.pull.batch.size" -> "5",
       "nats.pull.wait.time" -> "6",
-      "nats.pull.subscription.payload.compression" -> "zlib"
+      "nats.storage.payload-compression" -> "zlib"
     )
     val createConsumer = false
     val expectedConfig = NatsSourceConfig(


### PR DESCRIPTION
Discussed in https://github.com/nats-io/nats-spark-connector/issues/27