### PR TITLE
Rename streaming source class to leverage default

### DIFF
--- a/V2/nats-spark-connector/README.md
+++ b/V2/nats-spark-connector/README.md
@@ -29,7 +29,7 @@ For more information, please refer to the Spark documentation.
 An example Scala source configuration for the NATS connector follows:
 ```scala
 val initDF = spark
-  .format("nats")
+  .format("nats") // use "org.apache.spark.sql.nats" if you see DATA_SOURCE_NOT_FOUND
   .option("nats.host", "localhost")
   .option("nats.port", "4222")
   .option("nats.credential.file", "/Users/mrosti/shh/...")

--- a/V2/nats-spark-connector/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/V2/nats-spark-connector/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,1 +1,1 @@
-org.apache.spark.sql.nats.NatsStreamProvider
+org.apache.spark.sql.nats.DefaultSource

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsStreamProvider.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsStreamProvider.scala
@@ -15,7 +15,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import scala.collection.JavaConverters._
 
-class NatsStreamProvider
+class DefaultSource 
     extends DataSourceRegister
     with StreamSourceProvider
     with StreamSinkProvider {


### PR DESCRIPTION
I'm having an issue where trying to use `.format("nats")` results in a DATA_SOURCE_NOT_FOUND error. This occurs when the format alias is not being properly registered. This is happening when the jar library is loaded into the cluster. Something is off such that the source is not being registered. I found this issue in v2 but not with load_balanced. I scoured the code but couldn't figure out why they were different or how to fix it. However, I did find the workaround in this PR.

This PR changes the streaming source class to the default classname spark will try to use when a package path is passed -- for example `format("org.apache.spark.sql.nats")`. 

This works because...
> The provider argument [passed from format] can be either an alias (a simple name, e.g. parquet) or a fully-qualified class name (e.g. org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat). ([source](https://books.japila.pl/spark-sql-internals/DataSource/#lookupDataSource))

This approach is also used by the redshift connector [code](https://github.com/spark-redshift-community/spark-redshift/blob/master/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala#L33), [doc](https://github.com/spark-redshift-community/spark-redshift?tab=readme-ov-file#scala)

It would be great if using format("nats") worked however this PR provides an escape hatch even if the registration issue is eventually sussed and resolved.