### PR TITLE
JS-API-PREFIX and Parsing Headers

### DIFF
--- a/V2/nats-spark-connector/README.md
+++ b/V2/nats-spark-connector/README.md
@@ -48,6 +48,8 @@ val initDF = spark
   .option("nats.key-store.path", "/path/to/key-store")
   .option("nats.key-store.password", "key_store_password")
   .option("nats.tls.algorithm", "alg")
+  .option("nats.source.js.api-prefix", "source-js-api-prefix")
+  .option("nats.sink.js.api-prefix", "sink-js-api-prefix")
 ```
 
 JetStream schema

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsConnection.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsConnection.scala
@@ -4,7 +4,7 @@ import io.nats.client.{Connection, Nats, Options}
 import org.apache.spark.internal.Logging
 
 @SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))
-final case class NatsConnectionConfig(secretBytes: Array[Byte], url: String, params: Map[String, String])
+final case class NatsConnectionConfig(secretBytes: Array[Byte], url: String, params: Map[String, String], jsAPIPrefix: String)
 
 object NatsConnection extends Logging with Serializable {
 

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsRDD.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsRDD.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.sql.nats
 
-import io.nats.client.PullSubscribeOptions
+import io.nats.client.{JetStreamOptions, PullSubscribeOptions}
 import io.nats.client.impl.AckType
 import org.apache.spark.Partition
 import org.apache.spark.SparkContext
@@ -52,8 +52,9 @@ class NatsRDD(sc: SparkContext, natsSourceParams: NatsSourceParams)
       logDebug("Starting iterator")
       val pullSubscriptionConf = PullSubscribeOptions
         .fastBind(natsSourceParams.streamName, natsSourceParams.consumerName)
+      val jetStreamOptions = JetStreamOptions.builder().prefix(natsSourceParams.natsConnectionConfig.jsAPIPrefix).build()
       conn
-        .jetStream()
+        .jetStream(jetStreamOptions)
         .subscribe(None.orNull, pullSubscriptionConf)
         .fetch(natsSourceParams.batchSize, natsSourceParams.maxWait.toMillis)
         .iterator()
@@ -66,8 +67,9 @@ class NatsRDD(sc: SparkContext, natsSourceParams: NatsSourceParams)
   override protected def getPartitions: Array[Partition] = {
     logInfo("getPartitions")
     withConnection(natsSourceParams.natsConnectionConfig)(conn => {
+      val jetStreamOptions = JetStreamOptions.builder().prefix(natsSourceParams.natsConnectionConfig.jsAPIPrefix).build()
       val numPending = conn
-        .jetStream()
+        .jetStream(jetStreamOptions)
         .getConsumerContext(natsSourceParams.streamName, natsSourceParams.consumerName)
         .getConsumerInfo
         .getNumPending

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsSink.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsSink.scala
@@ -1,7 +1,6 @@
 package org.apache.spark.sql.nats
 
-import io.nats.client.Message
-import io.nats.client.PublishOptions
+import io.nats.client.{JetStreamOptions, Message, PublishOptions}
 import io.nats.client.impl.Headers
 import io.nats.client.impl.NatsMessage
 import org.apache.spark.internal.Logging
@@ -64,7 +63,9 @@ class NatsSink(natsPublisherConfig: NatsPublisherConfig) extends Sink with Loggi
       .as[NatsMessageRow]
       .foreachPartition((iterator: Iterator[NatsMessageRow]) => {
         withConnection(connectionConfig)(connection => {
-          val jetStream = connection.jetStream()
+
+          val jetStreamOptions = JetStreamOptions.builder().prefix(connectionConfig.jsAPIPrefix).build()
+          val jetStream = connection.jetStream(jetStreamOptions)
           val publishOptions =
             PublishOptions.builder().stream(stream).build()
           iterator.map(MessageBuilder(_)).foreach(jetStream.publish(_, publishOptions))

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsSource.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsSource.scala
@@ -1,11 +1,10 @@
 package org.apache.spark.sql.nats
 
-import io.nats.client.Message
+import io.nats.client.{JetStreamOptions, Message}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, MapData}
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.nats.NatsConnection.withConnection
@@ -18,7 +17,6 @@ import java.util.zip.Inflater
 import scala.collection.JavaConverters._
 import scala.collection.concurrent.TrieMap
 import scala.collection.convert.ImplicitConversions._
-import scala.collection.Iterator
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -46,12 +44,13 @@ object MessageToSparkRow {
   }
 
   def apply(message: Message, payloadCompression: String): InternalRow = {
-    val headers: Option[Map[String, Seq[String]]] =
+
+    val headers: Option[Map[UTF8String, Seq[UTF8String]]] =
       Option(message.getHeaders).map(
         _.entrySet()
           .toSet
           .map((me: util.Map.Entry[String, util.List[String]]) =>
-            (me.getKey, me.getValue.asScala.toSeq))
+            (UTF8String.fromString(me.getKey), me.getValue.asScala.map(UTF8String.fromString).toSeq))
           .toMap)
 
     val metadata = message.metaData()
@@ -59,6 +58,20 @@ object MessageToSparkRow {
     val messageContent = payloadCompression match {
       case "zlib" => decompress(message.getData) 
       case "none" => message.getData 
+    }
+
+    val headersMapData: Option[MapData] = {
+      if (headers.nonEmpty) {
+        Some(
+          headers.map { h =>
+            val keys = ArrayData.toArrayData(h.keys.toArray )
+            val values = ArrayData.toArrayData(h.values.map(v => ArrayData.toArrayData(v.toArray)).toArray)
+            new ArrayBasedMapData(keys, values)
+          }.orNull
+        )
+      } else {
+        None
+      }
     }
 
     val values: Seq[Any] = Seq(
@@ -69,7 +82,7 @@ object MessageToSparkRow {
       // content
       messageContent,
       // headers map
-      headers.orNull,
+      headersMapData.orNull,
       // domain
       UTF8String.fromString(metadata.getDomain),
       // stream
@@ -138,8 +151,9 @@ class NatsSource(sqlContext: SQLContext, natsSourceParams: NatsSourceParams)
   override def getOffset: Option[Offset] = {
     logInfo("getOffset")
     val pending = withConnection(natsSourceParams.natsConnectionConfig)(conn => {
+      val jetStreamOptions = JetStreamOptions.builder().prefix(natsSourceParams.natsConnectionConfig.jsAPIPrefix).build()
       val consumerInfo = conn
-        .jetStream()
+        .jetStream(jetStreamOptions)
         .getConsumerContext(natsSourceParams.streamName, natsSourceParams.consumerName)
         .getConsumerInfo
       consumerInfo.getNumWaiting + consumerInfo.getNumPending

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsStreamProvider.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/NatsStreamProvider.scala
@@ -1,6 +1,8 @@
 package org.apache.spark.sql.nats
 
+import io.nats.client.JetStreamOptions
 import io.nats.client.api.ConsumerConfiguration
+import io.nats.client.support.NatsJetStreamConstants
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.execution.streaming.Source
@@ -11,7 +13,7 @@ import org.apache.spark.sql.sources.StreamSourceProvider
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.StructType
 
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, Paths}
 import scala.collection.JavaConverters._
 
 class NatsStreamProvider
@@ -35,9 +37,11 @@ class NatsStreamProvider
       parameters: Map[String, String]): Source = {
     val config = NatsSourceConfig(parameters)
     val authFileBytes = Files.readAllBytes(Paths.get(config.jetStreamConfig.credentialsFile))
+    val jsApiPrefix = parameters.getOrElse(sourceJsAPIPrefix, NatsJetStreamConstants.DEFAULT_API_PREFIX)
+    val jetStreamOptions = JetStreamOptions.builder().prefix(jsApiPrefix).build()
     val connectionConfig = NatsConnectionConfig(
       authFileBytes,
-      s"nats://${config.jetStreamConfig.host}:${config.jetStreamConfig.port}", parameters)
+      s"nats://${config.jetStreamConfig.host}:${config.jetStreamConfig.port}", parameters, jsApiPrefix)
 
     if (config.subscriptionConfig.createConsumer) {
       val consumerConfiguration = ConsumerConfiguration
@@ -49,7 +53,7 @@ class NatsStreamProvider
         .filterSubjects(config.subscriptionConfig.consumerConfig.filterSubjects.asJava)
         .build()
       withConnection(connectionConfig)(
-        _.jetStreamManagement()
+        _.jetStreamManagement(jetStreamOptions)
           .addOrUpdateConsumer(config.subscriptionConfig.streamName, consumerConfiguration))
 
     }
@@ -74,10 +78,14 @@ class NatsStreamProvider
       outputMode: OutputMode): Sink = {
     val config = NatsSinkConfig(parameters)
     val authFileBytes = Files.readAllBytes(Paths.get(config.jetStreamConfig.credentialsFile))
+    val jsApiPrefix = parameters.getOrElse(sinkJsAPIPrefix, NatsJetStreamConstants.DEFAULT_API_PREFIX)
+
+    val connectionConfig = NatsConnectionConfig(
+      authFileBytes,
+      s"nats://${config.jetStreamConfig.host}:${config.jetStreamConfig.port}", parameters, jsApiPrefix)
+
     val publisherConfig = NatsPublisherConfig(
-      NatsConnectionConfig(
-        authFileBytes,
-        s"nats://${config.jetStreamConfig.host}:${config.jetStreamConfig.port}", parameters),
+      connectionConfig,
       config.stream)
     NatsSink(publisherConfig)
   }

--- a/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/package.scala
+++ b/V2/nats-spark-connector/src/main/scala/org/apache/spark/sql/nats/package.scala
@@ -23,6 +23,7 @@ package object nats {
   val SourceConsumerMaxAckPendingOption = "nats.pull.consumer.max.ack.pending"
   val SourceConsumerMaxBatchOption = "nats.pull.consumer.max.batch"
   val SourceConsumerFilterSubjectsOption = "nats.stream.subjects"
+  val sourceJsAPIPrefix = "nats.source.js.api-prefix"
 
   // Pull batcher config
   val SourcePullBatchSizeOption = "nats.pull.batch.size"
@@ -33,5 +34,6 @@ package object nats {
   val SinkJSPortOption = "nats.port"
   val SinkJSCredentialFileOption = "nats.credential.file"
   val SinkStreamNameOption = "nats.stream.name"
+  val sinkJsAPIPrefix = "nats.sink.js.api-prefix"
 
 }


### PR DESCRIPTION
#39 JS API Prefix Option
Added js api prefix for source and sink jetstream options 
#32 Parsing headers causes a map error
Converted headers to MapData object which is compatible and as required by Spark

Signed-off-by: Syam Pidikiti <syam.pidikiti@gmail.com>
